### PR TITLE
add method #47setOrginSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ It supports the Archethic Cryptography rules which are:
   ...
   tx.originSign(originPrivateKey)
   ```
+  ### Hardware Interaction
+  #### setOriginSign(hardwareOriginSign)
+  Set the originSignature of transaction returned by a hardware device.  
+
+  - `hardwareOriginSign` Transaction is signed by the origin shared private key of harware .It is a (Uint8Array) HardwareOriginSignature 
+
+  ```js
+  const archethic = require('archethic')
+  const tx = archethic.newTransactionBuilder("transfer")
+    .addUCOTransfer("0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", 0.420) 
+    .build("mysuperpassphraseorseed", 0) 
+    .originSign(hardwareOriginSign)
+  ```
   #### sendTransaction(tx, endpoint)
   Dispatch  the transaction to a node by serializing a GraphQL request
   

--- a/README.md
+++ b/README.md
@@ -236,17 +236,18 @@ It supports the Archethic Cryptography rules which are:
   tx.originSign(originPrivateKey)
   ```
   ### Hardware Interaction
-  #### setOriginSign(hardwareOriginSign)
-  Set the originSignature of transaction returned by a hardware device.  
-
-  - `hardwareOriginSign` Transaction is signed by the origin shared private key of harware .It is a (Uint8Array) HardwareOriginSignature 
+  #### setOriginSign(signature)
+  Setter method for the originSignature of transaction.
 
   ```js
   const archethic = require('archethic')
   const tx = archethic.newTransactionBuilder("transfer")
     .addUCOTransfer("0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", 0.420) 
     .build("mysuperpassphraseorseed", 0) 
-    .originSign(hardwareOriginSign)
+
+    const originPayload = tx.originSignaturePayload()
+    const originSignature = someFunctionToGetSignature(originPayload)
+    tx.setOriginSign(originSignature)
   ```
   #### sendTransaction(tx, endpoint)
   Dispatch  the transaction to a node by serializing a GraphQL request

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -323,7 +323,7 @@ module.exports = class TransactionBuilder {
         throw "'hardwareOriginSign' must be a string or Uint8Array"
       }  
 
-      if (typeof (prevSign) == "string") {
+      if (typeof (hardwareOriginSign) == "string") {
         if (!isHex(hardwareOriginSign)) {
           throw "'hardwareOrigin Signature' must be in hexadecimal form if it's string"
         }

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -316,21 +316,21 @@ module.exports = class TransactionBuilder {
 
   /**
    * Set the Txn's originSignature, method called from hardware_libs
-   * @param {String | Uint8Array} to hardwareOrigin Signature (hexadecimal)
+   * @param {String | Uint8Array} to Signature (hexadecimal)
    */
-    setOriginSign(hardwareOriginSign) {
-      if (typeof (hardwareOriginSign) !== "string" && !(hardwareOriginSign instanceof Uint8Array))       {
-        throw "'hardwareOriginSign' must be a string or Uint8Array"
-      }  
+  setOriginSign(signature) {
+    if (typeof (signature) !== "string" && !(signature instanceof Uint8Array))       {
+        throw "'signature' must be a string or Uint8Array"
+    }  
 
-      if (typeof (hardwareOriginSign) == "string") {
-        if (!isHex(hardwareOriginSign)) {
-          throw "'hardwareOrigin Signature' must be in hexadecimal form if it's string"
-        }
-        hardwareOriginSign = hexToUint8Array(hardwareOriginSign);
+    if (typeof (signature) == "string") {
+      if (!isHex(signature)) {
+          throw "'Signature' must be in hexadecimal form if it's string"
       }
+        signature = hexToUint8Array(signature);
+    }
 
-    this.originSignature = hardwareOriginSign
+    this.originSignature = signature
     return this
   }
 

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -315,6 +315,27 @@ module.exports = class TransactionBuilder {
   }
 
   /**
+   * Set the Txn's originSignature, method called from hardware_libs
+   * @param {String | Uint8Array} to hardwareOrigin Signature (hexadecimal)
+   */
+    setOriginSign(hardwareOriginSign) {
+      if (typeof (hardwareOriginSign) !== "string" && !(hardwareOriginSign instanceof Uint8Array))       {
+        throw "'hardwareOriginSign' must be a string or Uint8Array"
+      }  
+
+      if (typeof (prevSign) == "string") {
+        if (!isHex(hardwareOriginSign)) {
+          throw "'hardwareOrigin Signature' must be in hexadecimal form if it's string"
+        }
+        hardwareOriginSign = hexToUint8Array(hardwareOriginSign);
+      }
+
+    this.originSignature = hardwareOriginSign
+    return this
+  }
+
+
+  /**
    * Convert the transaction in JSON
    */
   toJSON() {


### PR DESCRIPTION
The shared secret used in Archethic is somewhat different from Diffie-Hellman key exchange.
The node randomly generates a shared secret based on Heuristic algos(like data etc) which act
as a shared origin private key for the  hardware device , which is decrypted by authorized key,
which is the origin public key of the hardware device.

### Example: 


-   3 Actors : 
-     -  The Node , The Software Wallet , And the hardware device :  (ex ledger)
-   When the first time a hardware device say ledger joins the network , through a software wallet.
    The Hardware generates Origin keys, and it is sent to node via a software wallet(ex met mask).
   To request for the authorized keys ,(which will be the origin public key of ledger)

- When later Hardware device needs to sign the transaction , it sends getOrginkey(origin publickey) 
 to get a origin shared private key.

-  The request is gone via software wallet to network node , where the node generates a random secret
   to be used as a private key , which is encrypted via ledger Origin Public Key(authorized key) and is sent 
   back to hardware wallet via software wallet.

- The hardware ledger decrypts the received origin shared private key via authorized keys i.e the Ledger origin
  public  key.

The Task is that a: 
- A Hardware library sits between the interaction of libjs  and ledger , which will use a 
method setOrginSign to set the Signature returned by ledger to the Transaction builder
this.originSignature .
 
