### PR TITLE
Fix multiple authorized key order in ownership

### DIFF
--- a/example/transactionBuilder.html
+++ b/example/transactionBuilder.html
@@ -385,11 +385,11 @@
       ownershipEl.appendChild(document.createElement("br"))
 
       let authorizedPublicKeyLabel = document.createElement("label")
-      authorizedPublicKeyLabel.setAttribute("for", "authPublicKey_0")
+      authorizedPublicKeyLabel.setAttribute("for", "authPublicKey_" + ownershipIndex)
 
       let authorizedPublicKeyInput = document.createElement("input")
       authorizedPublicKeyInput.setAttribute("type", "text")
-      authorizedPublicKeyInput.setAttribute("id", "authPublicKey_0")
+      authorizedPublicKeyInput.setAttribute("id", "authPublicKey_" + ownershipIndex)
       authorizedPublicKeyInput.setAttribute("placeholder", "Enter the public key to authorize")
       authorizedPublicKeyInput.setAttribute("class", "input")
 
@@ -408,7 +408,7 @@
       let publicKeyList = document.createElement("select")
       publicKeyList.setAttribute("multiple", "true")
       publicKeyList.setAttribute("class", "select")
-      publicKeyList.setAttribute("id", "publicKeys_0")
+      publicKeyList.setAttribute("id", "publicKeys_" + ownershipIndex)
       publicKeyList.style.width = "500px"
 
       ownershipEl.appendChild(authorizedPublicKeyLabel)

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -410,6 +410,9 @@ module.exports = class TransactionBuilder {
       const bufAuthKeyLength = Uint8Array.from(toByteArray(authorizedKeys.length))
       const authorizedKeysBuffer = [Uint8Array.from([bufAuthKeyLength.length]), bufAuthKeyLength]
 
+      // Sort authorized public key by alphabethic order
+      authorizedKeys.sort((a, b) => uint8ArrayToHex(a.publicKey).localeCompare(uint8ArrayToHex(b.publicKey)))
+
       authorizedKeys.forEach(({ publicKey, encryptedSecretKey }) => {
         authorizedKeysBuffer.push(publicKey)
         authorizedKeysBuffer.push(encryptedSecretKey)

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -97,7 +97,10 @@ module.exports = class TransactionBuilder {
       throw "'authorizedKeys must be an array"
     }
 
-    authorizedKeys = authorizedKeys.map(({ publicKey, encryptedSecretKey }) => {
+    const filteredAuthorizedKeys = []
+
+    // Remove duplicated public key
+    authorizedKeys.reduce((acc, { publicKey, encryptedSecretKey }) => {
       if (typeof (publicKey) !== "string" && !(publicKey instanceof Uint8Array)) {
         throw "Authorized public key must be a string or Uint8Array"
       }
@@ -120,13 +123,18 @@ module.exports = class TransactionBuilder {
         encryptedSecretKey = hexToUint8Array(encryptedSecretKey)
       }
 
-      return { publicKey: publicKey, encryptedSecretKey: encryptedSecretKey }
+      if (acc[publicKey]) return acc
 
-    })
+      filteredAuthorizedKeys.push({publicKey, encryptedSecretKey})
+
+      acc[publicKey] = encryptedSecretKey
+
+      return acc
+    }, {})
 
     this.data.ownerships.push({
       secret: secret,
-      authorizedKeys: authorizedKeys
+      authorizedKeys: filteredAuthorizedKeys
     })
 
     return this

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -30,6 +30,10 @@ describe("Transaction builder", () => {
         .addOwnership("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88", [{
           publicKey: "0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
           encryptedSecretKey: "00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
+        },
+        {
+          publicKey: "0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
+          encryptedSecretKey: "00601fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
         }])
 
       assert.deepStrictEqual(tx.data.ownerships[0].secret, hexToUint8Array("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"))

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -5,7 +5,7 @@ const { hexToUint8Array, uint8ArrayToHex, concatUint8Arrays, encodeInt32, encode
 const assert = require("assert")
 
 describe("Transaction builder", () => {
-  it ("should assign type when create a new transaction instance", () => {
+  it("should assign type when create a new transaction instance", () => {
     const tx = new TransactionBuilder("transfer")
     assert.strictEqual(tx.type, "transfer")
   })
@@ -69,7 +69,7 @@ describe("Transaction builder", () => {
   })
 
   describe("previousSignaturePayload", () => {
-    it ("should generate binary encoding of the transaction before signing", () => {
+    it("should generate binary encoding of the transaction before signing", () => {
 
       const code = `
               condition inherit: [
@@ -193,7 +193,7 @@ describe("Transaction builder", () => {
   })
 
   describe("originSignaturePayload", () => {
-    it ("should generate binary encoding of the transaction before signing", () => {
+    it("should generate binary encoding of the transaction before signing", () => {
 
       const secret = "mysecret"
       const content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet leo egestas, lobortis lectus a, dignissim orci."
@@ -210,6 +210,10 @@ describe("Transaction builder", () => {
       const tx = new TransactionBuilder("transfer")
         .addOwnership(secret, [{
           publicKey: "0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
+          encryptedSecretKey: "00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
+        },
+        {
+          publicKey: "0001a1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
           encryptedSecretKey: "00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
         }])
         .addUCOTransfer("0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", 0.2020)
@@ -244,9 +248,10 @@ describe("Transaction builder", () => {
         // Nb of byte to encode nb of authorized key
         Uint8Array.from([1]),
         // Nb of authorized keys
-        Uint8Array.from([1]),
+        Uint8Array.from([2]),
         // Authorized keys encoding
         concatUint8Arrays([
+          hexToUint8Array("0001a1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646"), hexToUint8Array("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"),
           hexToUint8Array("0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646"), hexToUint8Array("00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88")
         ]),
         // Nb of byte to encode nb of uco transfers
@@ -282,7 +287,7 @@ describe("Transaction builder", () => {
   })
 
   describe("originSign", () => {
-    it ("should sign the transaction with a origin private key", () => {
+    it("should sign the transaction with a origin private key", () => {
       const originKeypair = Crypto.deriveKeyPair("origin_seed", 0)
 
       const tx = new TransactionBuilder("transfer")
@@ -319,8 +324,8 @@ describe("Transaction builder", () => {
       assert.strictEqual(parsedTx.previousSignature, uint8ArrayToHex(previousSig))
       assert.strictEqual(parsedTx.originSignature, uint8ArrayToHex(originSig))
       assert.strictEqual(parsedTx.data.ownerships[0].secret, uint8ArrayToHex(Uint8Array.from([0, 1, 2, 3, 4])))
-      assert.deepStrictEqual(parsedTx.data.ledger.uco.transfers[0], { to: "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", amount: toBigInt(0.2193)})
-      assert.deepStrictEqual(parsedTx.data.ownerships[0].authorizedKeys, [{ publicKey: "0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", encryptedSecretKey: "00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"}])
+      assert.deepStrictEqual(parsedTx.data.ledger.uco.transfers[0], { to: "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", amount: toBigInt(0.2193) })
+      assert.deepStrictEqual(parsedTx.data.ownerships[0].authorizedKeys, [{ publicKey: "0001b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646", encryptedSecretKey: "00501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88" }])
     })
   })
 })


### PR DESCRIPTION
Fixes #20 

To be consistent with the node, the list of authorized keys in the ownership is sorted by alphabethic order when creating the payload for signature

Added test in testfile