### PR TITLE
Handle token's decimals property

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,14 +263,14 @@ This aims to prove the ownership or the delegatation of some secret to a given l
 Add a UCO transfer to the `data.ledger.uco.transfers` section of the transaction
 
 - `to` is hexadecimal encoding or Uint8Array representing the transaction address (recipient) to receive the funds
-- `amount` is the number of uco to send (float)
+- `amount` is the number of uco to send (in Big Int ref function `toBigInt`)
 
 #### addTokenTransfer(to, amount, tokenAddress, tokenId)
 
 Add a token transfer to the `data.ledger.token.transfers` section of the transaction
 
 - `to` is hexadecimal encoding or Uint8Array representing the transaction address (recipient) to receive the funds
-- `amount` is the number of uco to send (float)
+- `amount` is the number of uco to send (in Big Int ref function `toBigInt`)
 - `tokenAddress` is hexadecimal encoding or Uint8Array representing the token's address to spend
 - `tokenId` is the ID of the token to send (default to: 0)
 
@@ -552,7 +552,15 @@ import Archethic from "archethic"
 
 const archethic = new Archethic("https://testnet.archethic.net")
 const tx = ...
-const { fee: fee } = await archethic.transaction.getTransactionFee(tx)
+const fee = await archethic.transaction.getTransactionFee(tx)
+console.log(fee)
+{
+  fee: 11779421, // Big Int format (ref function fromBigInt)
+  rates: {
+    eur: 0.086326,
+    usd: 0.084913
+  }
+}
 ```
 
 ### getTransactionOwnerships(address)
@@ -848,14 +856,32 @@ const cipher = Crypto.aesEncrypt(
   <details>
   <summary>Utils</summary>
 
-### fromBigInt(number)
+### fromBigInt(number, decimals)
 
-Convert a big int number to a 8 decimals number (mainly use to display token amount)
+Convert a big int number to a x decimals number (mainly use to display token amount)
+- `number` Big Int number to convert to decimals number
+- `decimals` number of decimals needed (default to 8)
 
 ```js
 import { Utils } from "archethic";
-Utils.fromBigInt(1_253_000_000);
-// 12.53
+Utils.fromBigInt(1_253_450_000);
+// 12.5345
+Utils.fromBigInt(12_534_500, 6);
+// 12.5345
+```
+
+### toBigInt(number, decimals)
+
+Convert a decimals number to a BigInt number
+- `number` decimals number to convert to Big Int number
+- `decimals` number of decimals (default to 8)
+
+```js
+import { Utils } from "archethic";
+Utils.toBigInt(12.5345);
+// 1_253_450_000
+Utils.toBigInt(12.5345, 6);
+// 12_534_500
 ```
 
 ### originPrivateKey

--- a/README.md
+++ b/README.md
@@ -586,6 +586,33 @@ console.log(ownerships)[
   <details>
     <summary>Network</summary>
 
+### getToken(tokenAddress)
+
+Query a node to get the token definition (based on [AEIP2](https://github.com/archethic-foundation/aeip/blob/main/AEIP-2.md)) from an address.
+Returns also `genesis` address and `id`
+
+- `tokenAddress` is the transaction address of the token.
+
+```js
+import Archethic from "archethic";
+const archethic = new Archethic("https://testnet.archethic.net");
+
+await archethic.connect();
+const token = await archethic.network.getToken(tokenAddress);
+console.log(token);
+{
+  collection: [],
+  decimals: 8,
+  genesis: '0000D6979F125A91465E29A12F66AE40FA454A2AD6CE3BB40099DBDDFFAF586E195A',
+  id: '9DC6196F274B979E5AB9E3D7A0B03FEE3E4C62C7299AD46C8ECF332A2C5B6574',
+  name: 'Mining UCO rewards',
+  properties: {},
+  supply: 3340000000000000, // Big Int format (ref function fromBigInt)
+  symbol: 'MUCO',
+  type: 'fungible'
+}
+```
+
 ### addOriginKey(originPublicKey, certificate)
 
 Query a node to add a new origin public to be authorized to sign transaction with the corresponding private key (see OriginSign).

--- a/example/keychain/app.js
+++ b/example/keychain/app.js
@@ -1,5 +1,7 @@
 import Archethic, { Crypto, Utils } from 'archethic'
 
+const { toBigInt } = Utils
+
 let endpoint = document.querySelector("#endpoint").value;
 
 let archethic = new Archethic(endpoint);
@@ -129,7 +131,7 @@ window.sendTransaction = async () => {
   const tx = archethic.transaction
     .new()
     .setType("transfer")
-    .addUCOTransfer(recipientAddress, ucoAmount);
+    .addUCOTransfer(recipientAddress, toBigInt(parseFloat(ucoAmount)));
 
   const originPrivateKey = Utils.originPrivateKey;
 

--- a/example/transactionBuilder/app.js
+++ b/example/transactionBuilder/app.js
@@ -1,5 +1,7 @@
 import Archethic, { Utils, Crypto } from "archethic";
 
+const { toBigInt } = Utils
+
 let file_content = "";
 
 let transaction;
@@ -133,7 +135,7 @@ window.onClickAddTransfer = () => {
     return;
   }
 
-  ucoTransfers.push({ to: transfer_to, amount: transferAmount });
+  ucoTransfers.push({ to: transfer_to, amount: toBigInt(amount) });
 
   var option = document.createElement("option");
   option.text = transfer_to + ": " + transferAmount;
@@ -147,7 +149,7 @@ window.onClickAddTransfer = () => {
   document.querySelector("#uco_amount").value = "";
 };
 
-window.onClickAddTokenTransfer = () => {
+window.onClickAddTokenTransfer = async () => {
   var transfer_to = document.querySelector("#token_recipient_address").value;
   var transferAmount = document.querySelector("#token_amount").value;
   var transferToken = document.querySelector("#token_address").value;
@@ -166,9 +168,12 @@ window.onClickAddTokenTransfer = () => {
     return;
   }
 
+  const { decimals } = await archethic.network.getToken(transferToken)
+    .catch(() => { return { decimals: 8 } })
+
   tokenTransfers.push({
     to: transfer_to,
-    amount: transferAmount,
+    amount: toBigInt(amount, decimals),
     token: transferToken,
     tokenId: parseInt(transferTokenId),
   });

--- a/lib/api.js
+++ b/lib/api.js
@@ -159,6 +159,47 @@ export async function getTransactionOwnerships(address, endpoint) {
     });
 }
 
+export async function getToken(tokenAddress, endpoint) {
+  if (typeof tokenAddress !== "string" && !(address instanceof Uint8Array)) {
+    throw "'tokenAddress' must be a string or Uint8Array";
+  }
+
+  if (typeof tokenAddress == "string") {
+    if (!isHex(tokenAddress)) {
+      throw "'address' must be in hexadecimal form if it's string";
+    }
+  }
+
+  if (tokenAddress instanceof Uint8Array) {
+    tokenAddress = uint8ArrayToHex(tokenAddress);
+  }
+
+  const url = new URL("/api", endpoint);
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      query: `query {
+                    token(address: "${tokenAddress}") {
+                      genesis, name, symbol, supply, type
+                      properties, collection, id, decimals
+                    }
+              }`,
+    }),
+  })
+    .then(handleResponse)
+    .then((res) => {
+      if (res.errors || res.data == null) {
+        return [];
+      } else {
+        return res.data.token;
+      }
+    });
+}
+
 export async function addOriginKey(originPublicKey, certificate, endpoint) {
   if (
     typeof originPublicKey !== "string" &&

--- a/lib/network.js
+++ b/lib/network.js
@@ -26,4 +26,10 @@ export default class Network {
       API.subscribeToOracleUpdates(endpoint, callback, transport)
     );
   }
+
+  async getToken(tokenAddress) {
+    return this.core.requestNode((endpoint) => 
+      API.getToken(tokenAddress, endpoint)
+    );
+  }
 };

--- a/lib/transaction_builder.js
+++ b/lib/transaction_builder.js
@@ -149,7 +149,7 @@ export default class TransactionBuilder {
   /**
    * Add a UCO transfer to the transaction
    * @param {String | Uint8Array} to Address of the recipient (hexadecimal or binary buffer)
-   * @param {Float} amount Amount of UCO to transfer
+   * @param {Integrer} amount Amount of UCO to transfer (in bigint)
    */
   addUCOTransfer(to, amount) {
     if (typeof (to) !== "string" && !(to instanceof Uint8Array)) {
@@ -163,21 +163,18 @@ export default class TransactionBuilder {
       to = hexToUint8Array(to)
     }
 
-    if (isNaN(amount) && amount > 0.0) {
-      throw 'UCO transfer amount must be a number'
+    if (isNaN(amount) || amount <= 0) {
+      throw 'UCO transfer amount must be a positive number'
     }
 
-    this.data.ledger.uco.transfers.push({
-      to: to,
-      amount: toBigInt(amount)
-    })
+    this.data.ledger.uco.transfers.push({to, amount})
     return this
   }
 
   /**
    * Add a token transfer to the transaction
    * @param {String | Uint8Array} to Address of the recipient (hexadecimal or binary buffer)
-   * @param {Float} amount Amount of UCO to transfer
+   * @param {Integer} amount Amount of UCO to transfer (in bigint)
    * @param {String | Uint8Array} tokenAddress Address of token to spend (hexadecimal or binary buffer)
    * @param {Integer} tokenId ID of the token to use (default to 0)
    */
@@ -197,7 +194,7 @@ export default class TransactionBuilder {
       to = hexToUint8Array(to)
     }
 
-    if (isNaN(amount) && amount > 0.0) {
+    if (isNaN(amount) || amount <= 0) {
       throw 'Token transfer amount must be a positive number'
     }
 
@@ -208,13 +205,13 @@ export default class TransactionBuilder {
       tokenAddress = hexToUint8Array(tokenAddress)
     }
 
-    if (isNaN(tokenId) && tokenId < 0) {
+    if (isNaN(tokenId) || tokenId < 0) {
       throw "'tokenId' must be a valid integer >= 0"
     }
 
     this.data.ledger.token.transfers.push({
       to: to,
-      amount: toBigInt(amount),
+      amount: amount,
       token: tokenAddress,
       tokenId: tokenId
     })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,16 +105,20 @@ export function decodeInt32(bytes) {
 /**
  * Convert any number into a big int for 10^8 decimals
  */
-export function toBigInt(number) {
-  return Math.round(number * 100_000_000);
+export function toBigInt(number, decimals = 8) {
+  if (typeof number !== "number") throw "'number' must be an integer";
+  if (typeof decimals !== "number") throw "'decimals' must be an integer";
+  // Use bits manipulation (x << 0) to truncate value
+  return (number * Math.pow(10, decimals)) << 0
 };
 
 /**
  * Convert a big int number of 10^8 decimals into a decimal
  */
-export function fromBigInt(number) {
+export function fromBigInt(number, decimals = 8) {
   if (typeof number !== "number") throw "'number' must be an integer";
-  return number / 100_000_000;
+  if (typeof decimals !== "number") throw "'decimals' must be an integer";
+  return number / (Math.pow(10, decimals));
 };
 
 /**

--- a/test/network.js
+++ b/test/network.js
@@ -136,4 +136,38 @@ describe("Network", () => {
 
     assert.equal(eurPrice, 0.2);
   });
+
+  it("should get token description", async () => {
+    const expectedToken = {
+      collection: [],
+      decimals: 8,
+      genesis: '0000D6979F125A91465E29A12F66AE40FA454A2AD6CE3BB40099DBDDFFAF586E195A',
+      id: '9DC6196F274B979E5AB9E3D7A0B03FEE3E4C62C7299AD46C8ECF332A2C5B6574',
+      name: 'Mining UCO rewards',
+      properties: {},
+      supply: 3340000000000000,
+      symbol: 'MUCO',
+      type: 'fungible'
+    }
+
+    nock("http://localhost:4000", {})
+      .post("/api", {
+        query: `query {
+                    token(address: "1234") {
+                      genesis, name, symbol, supply, type
+                      properties, collection, id, decimals
+                    }
+              }`,
+      })
+      .reply(200, {
+        data: {
+          token: expectedToken
+        },
+      });
+
+    const network = new Network(archethic);
+    const token = await network.getToken('1234');
+
+    assert.deepEqual(token, expectedToken);
+  });
 });

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -86,7 +86,7 @@ describe("Transaction builder", () => {
     it("should add an uco transfer to the transaction data", () => {
       const tx = new TransactionBuilder("transfer").addUCOTransfer(
         "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-        10.03
+        toBigInt(10.03)
       );
 
       assert.strictEqual(tx.data.ledger.uco.transfers.length, 1);
@@ -107,7 +107,7 @@ describe("Transaction builder", () => {
     it("should add an token transfer to the transaction data", () => {
       const tx = new TransactionBuilder("transfer").addTokenTransfer(
         "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-        10.03,
+        toBigInt(10.03),
         "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646"
       );
 
@@ -160,11 +160,11 @@ describe("Transaction builder", () => {
         ])
         .addUCOTransfer(
           "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-          0.202
+          toBigInt(0.202)
         )
         .addTokenTransfer(
           "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-          100,
+          toBigInt(100),
           "0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
         )
         .setCode(code)
@@ -351,11 +351,11 @@ describe("Transaction builder", () => {
         ])
         .addUCOTransfer(
           "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-          0.202
+          toBigInt(0.202)
         )
         .addTokenTransfer(
           "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-          100,
+          toBigInt(100),
           "0000501fa2db78bcf8ceca129e6139d7e38bf0d61eb905441056b9ebe6f1d1feaf88"
         )
         .setCode(code)
@@ -477,7 +477,7 @@ describe("Transaction builder", () => {
       const tx = new TransactionBuilder("transfer")
         .addUCOTransfer(
           "0000b1d3750edb9381c96b1a975a55b5b4e4fb37bfab104c10b0b6c9a00433ec4646",
-          0.2193
+          toBigInt(0.2193)
         )
         .addOwnership(Uint8Array.from([0, 1, 2, 3, 4]), [
           {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,14 @@
-import { isHex, hexToUint8Array, uint8ArrayToHex, concatUint8Arrays, encodeInt32, encodeInt64, toByteArray } from "../lib/utils.js"
+import {
+  isHex,
+  hexToUint8Array,
+  uint8ArrayToHex,
+  concatUint8Arrays,
+  encodeInt32,
+  encodeInt64,
+  toByteArray,
+  toBigInt,
+  fromBigInt
+} from "../lib/utils.js"
 import assert from 'assert'
 
 describe("Utils", () => {
@@ -64,4 +74,23 @@ describe("Utils", () => {
     })
   })
 
+  describe("toBigInt", () => {
+    it ("should return Big Int with 8 decimals by default", () => {
+      assert.deepStrictEqual(toBigInt(12.5345), 1_253_450_000)
+    })
+
+    it ("should return Big Int with decimals passed in param", () => {
+      assert.deepStrictEqual(toBigInt(12.5345, 6), 12_534_500)
+    })
+  })
+
+  describe("fromBigInt", () => {
+    it ("should return 8 decimals number by default", () => {
+      assert.deepStrictEqual(fromBigInt(1_253_450_000), 12.5345)
+    })
+
+    it ("should return decimals number with decimals passed in param", () => {
+      assert.deepStrictEqual(fromBigInt(12_534_500, 6), 12.5345)
+    })
+  })
 })


### PR DESCRIPTION
Fixes #85 

Add a new network function to get the definition of a token.
Add new parameter to `fromBigInt` and `toBigInt` function which permit to define the number of decimals needed

Add unit test on `fromBigInt` and `toBigInt` function.

`getToken`function tested with transactionBuilder example