### PR TITLE
Fixed a typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,14 +914,14 @@ Some examples are present to see how to use the SDK
 ### Keychain
 
 ```bash
-cd examples/keychain
+cd example/keychain
 npm run start
 ```
 
 ### TransactionBuilder
 
 ```bash
-cd examples/transactionBuilder
+cd example/transactionBuilder
 npm run start
 ```
 


### PR DESCRIPTION
This PR fixes a typo in Readme - 

Changed - 
1. "cd examples/keychain" to "cd example/keychain"
2. "cd examples/transactionBuilder" to "cd example/transactionBuilder"