### PR TITLE
Keychain enhancement for smart contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,29 @@ const keychain = await archethic.account.getKeychain(accessKeychainSeed);
 const { publicKey } = keychain.deriveKeypair("uco", 0);
 ```
 
+#### ecEncryptServiceSeed(service, publicKeys)
+
+Use ec encryption on the seed for the list of authorizedPublicKeys
+
+- `service`: Service name to identify the derivation path to use
+- `authorizedPublicKeys`: List of public keys to encrypt the service seed
+
+```js
+import Archethic, { Keychain, Crypto }from "archethic";
+
+const archethic = new Archethic("http://testnet.archethic.net")
+await archethic.connect()
+
+const keychain = new Keychain(Crypto.randomSecretKey())
+    .addService("uco", "m/650'/uco")
+
+const storageNonce = await archethic.network.getStorageNoncePublicKey()
+
+const { secret, authorizedPublicKeys } = keychain.ecEncryptServiceSeed("uco", [storageNonce]);
+// secret and authorizedPublicKeys can be used to create an ownership
+const tx = archethic.transaction.new().addOwnership(secret, authorizedPublicKeys)
+```
+
 #### toDID()
 
 Return a Decentralized Identity document from the keychain. (This is used in the transaction's content of the keychain tx)
@@ -1257,6 +1280,7 @@ It creates a new keypair into hexadecimal format
 - `seed` is hexadecimal encoding or Uint8Array representing the transaction chain seed to be able to derive and generate the keys
 - `index` is the number of transactions in the chain, to generate the actual and the next public key (see below the cryptography section)
 - `curve` is the elliptic curve to use for the key generation (can be "ed25519", "P256", "secp256k1") - default to: "ed25519"
+- `origin_id` is the origin of the public key (can be 0 for "on chain wallet", 1 for "software" or 2 for "tpm") - default to: 1
 
 ```js
 import { Crypto } from "archethic";

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -214,6 +214,7 @@ export function derivePrivateKey(seed: string | Uint8Array, index: number): Uint
  * @param {String} seed Keypair derivation seed
  * @param {number} index Number to identify the order of keys to generate
  * @param {String} curve Elliptic curve to use ("ed25519", "P256", "secp256k1")
+ * @param {number} origin_id Origin id of the public key (0, 1, 2) = ("on chain wallet", "software", "tpm")
  */
 export function deriveKeyPair(
     seed: string | Uint8Array,

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -215,14 +215,18 @@ export function derivePrivateKey(seed: string | Uint8Array, index: number): Uint
  * @param {number} index Number to identify the order of keys to generate
  * @param {String} curve Elliptic curve to use ("ed25519", "P256", "secp256k1")
  */
-export function deriveKeyPair(seed: string | Uint8Array, index: number = 0, curve = Curve.ed25519): Keypair {
-
+export function deriveKeyPair(
+    seed: string | Uint8Array,
+    index: number = 0,
+    curve = Curve.ed25519,
+    origin_id: number = SOFTWARE_ID
+): Keypair {
     if (index < 0) {
         throw "'index' must be a positive number"
     }
 
     const pvBuf = derivePrivateKey(seed, index)
-    return generateDeterministicKeyPair(pvBuf, curve, SOFTWARE_ID)
+    return generateDeterministicKeyPair(pvBuf, curve, origin_id)
 }
 
 /**

--- a/tests/keychain.test.ts
+++ b/tests/keychain.test.ts
@@ -1,7 +1,8 @@
 
 import Keychain, { keyToJWK } from "../src/keychain"
 import { uint8ArrayToHex, concatUint8Arrays, wordArrayToUint8Array } from "../src/utils"
-import { deriveAddress, deriveKeyPair, ecDecrypt, aesDecrypt } from "../src/crypto"
+import { deriveAddress, deriveKeyPair, ecDecrypt, aesDecrypt, verify } from "../src/crypto"
+import TransactionBuilder from "../src/transaction_builder";
 // @ts-ignore
 import CryptoJS from "crypto-js";
 //import TransactionBuilder from "../lib/transaction_builder.js"
@@ -166,7 +167,7 @@ describe("Keychain", () => {
         })
     })
 
-    /*describe("buildTransaction", () => {
+    describe("buildTransaction", () => {
         it("should build the transaction and the related signature", () => {
             const keychain = new Keychain("seed")
             keychain.addService("uco", "m/650'/0/0")
@@ -180,13 +181,12 @@ describe("Keychain", () => {
             const { publicKey } = keychain.deriveKeypair("uco")
             const address = keychain.deriveAddress("uco", 1)
 
-            assert.deepStrictEqual(tx.address, address)
-            assert.deepStrictEqual(tx.previousPublicKey, publicKey)
+            expect(tx.address).toStrictEqual(address)
+            expect(tx.previousPublicKey).toStrictEqual(publicKey)
 
-            assert.strictEqual(verify(tx.previousSignature, tx.previousSignaturePayload(), tx.previousPublicKey), true)
+            expect(verify(tx.previousSignature, tx.previousSignaturePayload(), tx.previousPublicKey)).toStrictEqual(true)
         })
-    })*/
-
+    })
 })
 
 


### PR DESCRIPTION
This PR aims to facilitate the usage of the Keychain when using smart contracts:
- Create a new service derivation method to have the same generated private keys between keychain and node running smart contracts. This method is based on the derivation path that does not contains the index `m/650'/service/0` => `m/650'/service`
- Add a new function to create an ownership with the service seed a secret for smart contract `Keychain.ecEncryptServiceSeed()`
- Re implement the function `Keychain.build_transaction` that disappeared 