### PR TITLE
Update build command in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,7 @@ Some examples are present to see how to use the SDK
 
 ```bash
 cd example/keychain
+npm install
 npm run start
 ```
 
@@ -1348,6 +1349,7 @@ npm run start
 
 ```bash
 cd example/transactionBuilder
+npm install
 npm run start
 ```
 

--- a/example/addressGenerator/package.json
+++ b/example/addressGenerator/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "../.."

--- a/example/keychain/package.json
+++ b/example/keychain/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/publicKeyGenerator/package.json
+++ b/example/publicKeyGenerator/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/rpcAccountSubscription/package.json
+++ b/example/rpcAccountSubscription/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/rpcCurrentAccount/package.json
+++ b/example/rpcCurrentAccount/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/rpcDeriveKeypairAddress/package.json
+++ b/example/rpcDeriveKeypairAddress/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/rpcService/package.json
+++ b/example/rpcService/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/rpcTransactionBuilder/package.json
+++ b/example/rpcTransactionBuilder/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."

--- a/example/transactionBuilder/package.json
+++ b/example/transactionBuilder/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "npm run build && http-server",
-    "build": "./build.js"
+    "build": "node ./build.js"
   },
   "dependencies": {
     "@archethicjs/sdk": "file:../.."


### PR DESCRIPTION
This pull request updates the build command in the samples' package.json.
The build command now uses the "node" command to run the build.js script.
This change ensures that the build process runs correctly.
Added the npm install command to the “Examples” README section so you can start the example from scratch.