### PR TITLE
Fix transaction sender methods and error handling

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -43,7 +43,7 @@ export class ExtendedTransactionBuilder extends TransactionBuilder {
   }
 
   //Override TransactionSender.send to use the node resolution
-  send(confirmationThreshold: number, timeout: number) {
+  send(confirmationThreshold?: number, timeout?: number) {
     this.core.requestNode((endpoint) => this.sender.send(this, endpoint, confirmationThreshold, timeout));
   }
 

--- a/src/transaction_sender.ts
+++ b/src/transaction_sender.ts
@@ -69,19 +69,19 @@ export default class TransactionSender {
         break;
 
       default:
-        throw "Event " + event + " is not supported";
+        throw new Error("Event " + event + " is not supported");
     }
 
     return this;
   }
 
   async send(tx: TransactionBuilder, endpoint: string, confirmationThreshold: number = 100, timeout: number = 60) {
-    if (confirmationThreshold < 0 && confirmationThreshold > 100) {
-      throw "'confirmationThreshold' must be an integer between 0 and 100";
+    if (confirmationThreshold < 0 || confirmationThreshold > 100) {
+      throw new Error("'confirmationThreshold' must be an integer between 0 and 100");
     }
 
     if (timeout <= 0) {
-      throw "'timeout' must be an integer greater than 0";
+      throw new Error("'timeout' must be an integer greater than 0");
     }
 
     const txAddress = uint8ArrayToHex(tx.address);
@@ -146,7 +146,7 @@ export default class TransactionSender {
           break;
 
         default:
-          throw "Event " + event + " is not supported";
+          throw new Error("Event " + event + " is not supported");
       }
     } else {
       absinthe.cancel(this.absintheSocket as AbsintheSocket, this.confirmationNotifier);

--- a/src/transaction_sender.ts
+++ b/src/transaction_sender.ts
@@ -177,7 +177,7 @@ async function waitConfirmations(
   const notifier = absinthe.send(absintheSocket, operation);
   return absinthe.observe(absintheSocket, notifier, (result: any) => {
     if (result.data.transactionConfirmed) {
-      const { nbConfirmations: nbConfirmations, maxConfirmations: maxConfirmations } = result.data.transactionConfirmed;
+      const { nbConfirmations, maxConfirmations } = result.data.transactionConfirmed;
 
       handler(nbConfirmations, maxConfirmations);
     }
@@ -196,7 +196,7 @@ async function waitError(address: string | Uint8Array, absintheSocket: any, hand
   const notifier = absinthe.send(absintheSocket, operation);
   return absinthe.observe(absintheSocket, notifier, (result: any) => {
     if (result.data.transactionError) {
-      const { context: context, reason: reason } = result.data.transactionError;
+      const { context, reason } = result.data.transactionError;
       handler(context, reason);
     }
   });

--- a/src/transaction_sender.ts
+++ b/src/transaction_sender.ts
@@ -35,8 +35,6 @@ export default class TransactionSender {
 
     this.timeout = undefined;
     this.nbConfirmationReceived = 0;
-
-    return this;
   }
 
   /**


### PR DESCRIPTION
This pull request fixes several issues in the `TransactionSender` class and improves error handling. The changes include:

- Updating the `send` method in `ExtendedTransactionBuilder` to make the `confirmationThreshold` and `timeout` parameters optional.

- Removing an unnecessary return statement in the `TransactionSender` constructor.

- Fixing error handling by throwing an `Error` object instead of a string.

- Fixing a destructuring assignment in the `send` method.