### PR TITLE
Add new methods and options to ArchethicRPCClient and TransactionBuilder

### DIFF
--- a/src/api/wallet_rpc.ts
+++ b/src/api/wallet_rpc.ts
@@ -385,4 +385,14 @@ export class ArchethicRPCClient {
   onCurrentAccountChange(listener: Function): PromiseLike<RpcSubscription> | undefined {
     return this._subscribe("subscribeCurrentAccount", {}, listener);
   }
+
+  /**
+   * Refreshes the current account.
+   *
+   */
+  refreshCurrentAccount(): void {
+    this._ensuresConnectionAlive();
+
+    this.client?.request("refreshCurrentAccount", new RpcRequest(this.origin));
+  }
 }

--- a/src/transaction_builder.ts
+++ b/src/transaction_builder.ts
@@ -54,6 +54,7 @@ export default class TransactionBuilder {
   public previousPublicKey: Uint8Array;
   public previousSignature: Uint8Array;
   public originSignature: Uint8Array;
+  public generateEncryptedSeedSC: boolean;
 
   /**
    * Create a new instance of the transaction builder
@@ -79,6 +80,7 @@ export default class TransactionBuilder {
     this.previousPublicKey = new Uint8Array();
     this.previousSignature = new Uint8Array();
     this.originSignature = new Uint8Array();
+    this.generateEncryptedSeedSC = false;
   }
 
   /**
@@ -246,6 +248,15 @@ export default class TransactionBuilder {
     addr = maybeHexToUint8Array(addr);
 
     this.address = addr;
+    return this;
+  }
+
+  /**
+   * Add a encrypted (by storage nonce public key) seed in the transaction's ownerships to allow nodes to manage smart contract
+   * @param {boolean} generateEncryptedSeedSC Generate encrypted seed for smart contract
+   */
+  setGenerateEncryptedSeedSC(generateEncryptedSeedSC: boolean) {
+    this.generateEncryptedSeedSC = generateEncryptedSeedSC;
     return this;
   }
 

--- a/src/transaction_builder.ts
+++ b/src/transaction_builder.ts
@@ -476,7 +476,8 @@ export default class TransactionBuilder {
       },
       previousPublicKey: uint8ArrayToHex(this.previousPublicKey),
       previousSignature: uint8ArrayToHex(this.previousSignature),
-      originSignature: this.originSignature && uint8ArrayToHex(this.originSignature)
+      originSignature: this.originSignature && uint8ArrayToHex(this.originSignature),
+      generateEncryptedSeedSC: this.generateEncryptedSeedSC
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,7 @@ export type TransactionRPC = {
   previousPublicKey: string;
   previousSignature: string;
   originSignature?: string;
+  generateEncryptedSeedSC?: boolean;
 };
 
 export type TransactionFee = {

--- a/tests/transaction_builder.test.ts
+++ b/tests/transaction_builder.test.ts
@@ -446,6 +446,13 @@ describe("Transaction builder", () => {
 
       expect(tx.generateEncryptedSeedSC).toEqual(generateEncryptedSeedSC);
     });
+    it("should affect the TransactionRPC", () => {
+      const generateEncryptedSeedSC = true;
+      const tx = new TransactionBuilder("transfer").setGenerateEncryptedSeedSC(generateEncryptedSeedSC);
+      const txRPC = tx.toNodeRPC()
+
+      expect(txRPC).toHaveProperty("generateEncryptedSeedSC", true);
+    });
   });
 
   describe("build", () => {

--- a/tests/transaction_builder.test.ts
+++ b/tests/transaction_builder.test.ts
@@ -439,6 +439,15 @@ describe("Transaction builder", () => {
     });
   });
 
+  describe("setGenerateEncryptedSeedSC", () => {
+    it("should set this.generateEncryptedSeedSC in transaction builder", () => {
+      const generateEncryptedSeedSC = true;
+      const tx = new TransactionBuilder("transfer").setGenerateEncryptedSeedSC(generateEncryptedSeedSC);
+
+      expect(tx.generateEncryptedSeedSC).toEqual(generateEncryptedSeedSC);
+    });
+  });
+
   describe("build", () => {
     it("should build the transaction and the related signature", () => {
       const tx = new TransactionBuilder("transfer")


### PR DESCRIPTION
This pull request adds new functionality to the ArchethicRPCClient and TransactionBuilder classes.

### ArchethicRPCClient

- Added a new method `refreshCurrentAccount()` to refresh the current account.

### TransactionBuilder

- Added a new option `generateEncryptedSeedSC` to allow the generation of an encrypted seed for smart contracts.

- Added a new method `setGenerateEncryptedSeedSC()` to set the `generateEncryptedSeedSC` option.

Fixes #160