### PR TITLE
Add RpcError type and RpcErrorCode.ServiceAlreadyExists

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -59,7 +59,8 @@ export enum RpcErrorCode {
   ServiceNotFound = 5007,
   UserRejected = 4001,
   UnknownAccount = 5005,
-  Other = 5000
+  Other = 5000,
+  ServiceAlreadyExists = 5008
 }
 
 export type RpcSubscription = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,5 @@
 import { TransactionFee, TransactionRPC } from "../types";
+import { JSONRPCError } from "json-rpc-2.0";
 
 export type NodeRpcMethods = {
   contract_fun(params: { contract: string; function: string; args?: any[] }): any;
@@ -47,6 +48,7 @@ export enum ConnectionState {
   Connecting = "WalletRPCConnection_connecting",
   Open = "WalletRPCConnection_open"
 }
+
 export enum RpcErrorCode {
   UnsupportedMethod = -32601,
   Timeout = 5001,
@@ -62,6 +64,8 @@ export enum RpcErrorCode {
   Other = 5000,
   ServiceAlreadyExists = 5008
 }
+
+export type RpcError = JSONRPCError;
 
 export type RpcSubscription = {
   id: string;

--- a/src/api/wallet_rpc.ts
+++ b/src/api/wallet_rpc.ts
@@ -22,7 +22,7 @@ export class RpcRequest {
    * @param {Object} payload Request payload
    * @param {number} version Wallet Rpc protocol version
    */
-  constructor(origin: RpcRequestOrigin, payload = {}, version = 1) {
+  constructor(origin: RpcRequestOrigin, payload: object = {}, version: number = 1) {
     this.origin = origin;
     this.version = version;
     this.payload = payload;
@@ -38,8 +38,6 @@ export class ArchethicRPCClient {
   static _instance: ArchethicRPCClient;
   constructor() {
     this.origin = { name: "" };
-    this.client;
-    this.websocket;
     this._connectionStateEventTarget = new EventTarget();
     this._rpcNotificationEventTarget = new EventTarget();
   }
@@ -57,7 +55,7 @@ export class ArchethicRPCClient {
   /**
    * @param {RpcRequestOrigin} origin Identifying data about the client application.
    */
-  setOrigin(origin: RpcRequestOrigin): ArchethicRPCClient {
+  setOrigin(origin: RpcRequestOrigin): this {
     this.origin = origin;
     return this;
   }
@@ -203,7 +201,7 @@ export class ArchethicRPCClient {
    * @param {function(String)} listener
    * @return {ArchethicRPCClient}
    */
-  onconnectionstatechange(listener: Function): ArchethicRPCClient {
+  onconnectionstatechange(listener: Function): this {
     this._connectionStateEventTarget.addEventListener(ConnectionState.Connecting, () => {
       listener(ConnectionState.Connecting);
     });
@@ -219,7 +217,7 @@ export class ArchethicRPCClient {
   /**
    * @return {ArchethicRPCClient}
    */
-  unsubscribeconnectionstatechange() {
+  unsubscribeconnectionstatechange(): this {
     this._connectionStateEventTarget.removeEventListener(ConnectionState.Connecting, null);
     this._connectionStateEventTarget.removeEventListener(ConnectionState.Open, null);
     this._connectionStateEventTarget.removeEventListener(ConnectionState.Closed, null);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -4,6 +4,7 @@ import TransactionSender from "./transaction_sender.js";
 import * as API from "./api.js";
 import Archethic from "./index.js";
 import { Ownership, TransactionFee } from "./types.js";
+import { SendTransactionResponse } from "./api/types.js";
 
 export default class Transaction {
   core: Archethic;
@@ -16,7 +17,7 @@ export default class Transaction {
     return new this.builder(this.core);
   }
 
-  send(tx: TransactionBuilder) {
+  send(tx: TransactionBuilder): Promise<SendTransactionResponse> {
     return this.core.rpcNode!.sendTransaction(tx);
   }
 
@@ -43,17 +44,17 @@ export class ExtendedTransactionBuilder extends TransactionBuilder {
   }
 
   //Override TransactionSender.send to use the node resolution
-  send(confirmationThreshold?: number, timeout?: number) {
+  send(confirmationThreshold?: number, timeout?: number): void {
     this.core.requestNode((endpoint) => this.sender.send(this, endpoint, confirmationThreshold, timeout));
   }
 
   //Use of composition as multi inheritance model
-  on(eventName: string, fun: Function) {
+  on(eventName: string, fun: Function): this {
     this.sender.on(eventName, fun);
     return this;
   }
 
-  unsubscribe(eventName: string) {
+  unsubscribe(eventName: string): this {
     this.sender.unsubscribe(eventName);
     return this;
   }

--- a/src/transaction_sender.ts
+++ b/src/transaction_sender.ts
@@ -3,6 +3,7 @@ import absinthe from "./api/absinthe.js";
 import TransactionBuilder from "./transaction_builder.js";
 import { AbsintheSocket } from "@absinthe/socket";
 import Archethic from "./index.js";
+import { RpcError } from "./api/types.js";
 
 const senderContext = "SENDER";
 
@@ -75,7 +76,12 @@ export default class TransactionSender {
     return this;
   }
 
-  async send(tx: TransactionBuilder, endpoint: string, confirmationThreshold: number = 100, timeout: number = 60) {
+  async send(
+    tx: TransactionBuilder,
+    endpoint: string,
+    confirmationThreshold: number = 100,
+    timeout: number = 60
+  ): Promise<TransactionSender> {
     if (confirmationThreshold < 0 || confirmationThreshold > 100) {
       throw new Error("'confirmationThreshold' must be an integer between 0 and 100");
     }
@@ -109,8 +115,7 @@ export default class TransactionSender {
       .then(() => {
         handleSend.call(this, timeout);
       })
-      .catch((err) => handleError.call(this, senderContext, err));
-
+      .catch((err: RpcError) => handleError.call(this, senderContext, err));
     return this;
   }
 
@@ -249,5 +254,5 @@ function handleSend(this: TransactionSender, timeout: number) {
     absinthe.cancel(this.absintheSocket as AbsintheSocket, this.errorNotifier);
 
     this.onTimeout.forEach((func) => func(this.nbConfirmationReceived, this));
-  }, timeout * 1_000);
+  }, timeout * 1000);
 }


### PR DESCRIPTION
This pull request adds the RpcError type and the RpcErrorCode.ServiceAlreadyExists enum value. It also includes refactoring of the transaction_sender and wallet_rpc files. 
Fixes #122.