### PR TITLE
feat(keychain): add toJSON() method to Keychain class

### DIFF
--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -293,6 +293,26 @@ export default class Keychain {
 
     return { secret, authorizedPublicKeys };
   }
+
+  /**
+   * Converts the Keychain object to a JSON representation.
+   * @returns The JSON representation of the Keychain object.
+   */
+  toJSON(): Object {
+    const decodedKeys: { [key: string]: string | string[] } = {};
+    for (const key in this) {
+      if (this.hasOwnProperty(key)) {
+        if (this[key] instanceof Uint8Array) {
+          decodedKeys[key] = new TextDecoder().decode(this[key] as Uint8Array);
+        } else if (Array.isArray(this[key])) {
+          decodedKeys[key] = (this[key] as Uint8Array[]).map((value) => uint8ArrayToHex(value));
+        } else {
+          decodedKeys[key] = this[key] as string;
+        }
+      }
+    }
+    return JSON.stringify(decodedKeys);
+  }
 }
 
 function deriveArchethicKeypair(
@@ -375,6 +395,7 @@ function readByte(binary: Uint8Array, pos: number, size: number): { byte: number
     pos: pos + size
   };
 }
+
 function readBytes(binary: Uint8Array, pos: number, size: number): { bytes: Uint8Array; pos: number } {
   return {
     bytes: binary.slice(pos, pos + size),

--- a/tests/keychain.test.ts
+++ b/tests/keychain.test.ts
@@ -193,4 +193,27 @@ describe("Keychain", () => {
       expect(verify(tx.previousSignature, tx.previousSignaturePayload(), tx.previousPublicKey)).toStrictEqual(true);
     });
   });
+
+  describe("toJSON", () => {
+    it("should return the JSON representation of the keychain", () => {
+      const seed = "abcdef";
+      const { publicKey } = deriveKeyPair(seed, 0);
+      const keychain = new Keychain(seed, 2).addService("uco", "m/650'/0/0").addAuthorizedPublicKey(publicKey);
+
+      const expectedJSON = JSON.stringify({
+        seed: seed,
+        version: 2,
+        services: {
+          uco: {
+            derivationPath: "m/650'/0/0",
+            curve: "ed25519",
+            hashAlgo: "sha256"
+          }
+        },
+        authorizedPublicKeys: [uint8ArrayToHex(publicKey)]
+      });
+
+      expect(keychain.toJSON()).toEqual(expectedJSON);
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds a new method, toJSON(), to the Keychain class. The toJSON() method converts the Keychain object to a JSON representation. This allows for easy debug Keychain objects.